### PR TITLE
Add transaction opcode analysis SPA

### DIFF
--- a/packages/neon-dappkit/README.md
+++ b/packages/neon-dappkit/README.md
@@ -52,6 +52,8 @@ Neon-Dappkit has 4 main components:
 - [NeonEventListener](https://github.com/CityOfZion/neon-dappkit/blob/main/packages/neon-dappkit/NEON-EVENT-LISTENER.md): Listen to events from the Neo3 Blockchain.
 
 Check out some examples in [examples folder](https://github.com/CityOfZion/neon-dappkit/packages/neon-dappkit/examples)
+including the `txFeeAnalyzer` sample that breaks down transaction opcode usage via
+a small web interface.
 
 
 ## Quick Example

--- a/packages/neon-dappkit/examples/blockInfo.ts
+++ b/packages/neon-dappkit/examples/blockInfo.ts
@@ -1,0 +1,21 @@
+import { NeonInvoker } from '@cityofzion/neon-dappkit'
+import { rpc } from '@cityofzion/neon-js'
+
+async function main() {
+  const rpcAddress = 'https://node.neodepot.org'
+  const invoker = await NeonInvoker.init({ rpcAddress })
+  console.log(`Connected using network magic: ${invoker['options'].networkMagic}`)
+
+  const client = new rpc.RPCClient(rpcAddress)
+  const blockCount = await client.getBlockCount()
+  console.log(`Current block count: ${blockCount}`)
+
+  const latestBlock = await client.getBlock(blockCount - 1, true)
+  console.log(`Latest block index: ${latestBlock.index}`)
+  console.log(`Transaction count in latest block: ${latestBlock.tx.length}`)
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})

--- a/packages/neon-dappkit/examples/txFeeAnalyzer/index.html
+++ b/packages/neon-dappkit/examples/txFeeAnalyzer/index.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Transaction Fee Analyzer</title>
+  <style>
+    body { font-family: sans-serif; margin: 2em; }
+    #result { white-space: pre-wrap; background: #f0f0f0; padding: 1em; }
+  </style>
+</head>
+<body>
+  <h1>Transaction Fee Analyzer</h1>
+  <label>Transaction ID: <input id="txid" style="width: 420px;"></label>
+  <button id="analyze">Analyze</button>
+  <div id="progress"></div>
+  <pre id="result"></pre>
+  <script>
+    const txInput = document.getElementById('txid');
+    const progressEl = document.getElementById('progress');
+    const resultEl = document.getElementById('result');
+    document.getElementById('analyze').onclick = async () => {
+      const txid = txInput.value.trim();
+      if (!txid) return;
+      progressEl.textContent = 'Processing...';
+      resultEl.textContent = '';
+      try {
+        const res = await fetch('/analyze?txid=' + txid);
+        const data = await res.json();
+        progressEl.textContent = 'Done';
+        resultEl.textContent = JSON.stringify(data, null, 2);
+      } catch (err) {
+        progressEl.textContent = 'Error';
+        resultEl.textContent = err.message;
+      }
+    };
+  </script>
+</body>
+</html>

--- a/packages/neon-dappkit/examples/txFeeAnalyzer/server.ts
+++ b/packages/neon-dappkit/examples/txFeeAnalyzer/server.ts
@@ -1,0 +1,48 @@
+import http from 'http'
+import { URL } from 'url'
+import fs from 'fs'
+import path from 'path'
+import { rpc, sc, u } from '@cityofzion/neon-js'
+const rpcAddress = 'https://node.neodepot.org'
+const client = new rpc.RPCClient(rpcAddress)
+
+const index = fs.readFileSync(path.join(__dirname, 'index.html'))
+
+function opcodeFrequency(scriptHex: string): Record<string, number> {
+  const bytes = u.HexString.fromHex(scriptHex).toArray()
+  const freq: Record<string, number> = {}
+  for (const b of bytes) {
+    const name = sc.OpCode[b] || `0x${b.toString(16)}`
+    freq[name] = (freq[name] || 0) + 1
+  }
+  return freq
+}
+
+http.createServer(async (req, res) => {
+  const url = new URL(req.url || '/', `http://${req.headers.host}`)
+  if (url.pathname === '/analyze') {
+    const txid = url.searchParams.get('txid')
+    if (!txid) {
+      res.writeHead(400)
+      res.end('missing txid')
+      return
+    }
+    try {
+      const raw = await client.getRawTransaction(txid, true)
+      const log = await client.getApplicationLog(txid)
+      const freq = opcodeFrequency(raw.script)
+      const totalGas = parseFloat(log.executions[0].gasconsumed)
+      res.setHeader('Content-Type', 'application/json')
+      res.end(JSON.stringify({ txid, totalGas, opcodeFrequency: freq }, null, 2))
+    } catch (e: any) {
+      res.writeHead(500)
+      res.end(JSON.stringify({ error: e.message }))
+    }
+    return
+  }
+
+  res.setHeader('Content-Type', 'text/html')
+  res.end(index)
+}).listen(8080, () => {
+  console.log('Open http://localhost:8080 in your browser')
+})


### PR DESCRIPTION
## Summary
- add `txFeeAnalyzer` example with minimal web UI and Node server
- document new sample in README

## Testing
- `pnpm install` *(fails: no package manifest)*
- `pnpm test` *(fails: no package.json found)*

------
https://chatgpt.com/codex/tasks/task_e_687fcda4f350832fa2ac9dbfabd77afa